### PR TITLE
build: fix mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,4 @@
 pull_request_rules:
-  - name: Automatic merge on approval
-    conditions:
-      - label=ready-to-merge
-      - check-success=build
-    actions:
-      merge:
-        method: squash
-        commit_message: title+body
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author=dependabot[bot]


### PR DESCRIPTION
Remove deprecated option commit_message (removed on April 25th, 2022)
